### PR TITLE
fix : echo -n옵션때 파일로 리다이렉션이 안되는 버그 고침. 문제는 printf였는데 자세히는 알아봐야함

### DIFF
--- a/jaemjeon_jisookim_minishell/main/src/built_in/ft_echo.c
+++ b/jaemjeon_jisookim_minishell/main/src/built_in/ft_echo.c
@@ -6,7 +6,7 @@
 /*   By: jaemjeon <jaemjeon@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/02 16:44:01 by jisookim          #+#    #+#             */
-/*   Updated: 2022/09/15 15:15:27 by jaemjeon         ###   ########.fr       */
+/*   Updated: 2022/09/22 16:27:35 by jaemjeon         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,13 +27,14 @@ void	printing_tokens(t_token *to_print_tokenlst, int n_option_flag)
 {
 	while (to_print_tokenlst != NULL)
 	{
-		printf("%s ", to_print_tokenlst->string_value);
+		ft_putstr_fd(to_print_tokenlst->string_value, 1);
+		ft_putchar_fd(' ', 1);
 		to_print_tokenlst = to_print_tokenlst->next;
 	}
 	if (n_option_flag == TRUE)
-		printf("\b");
+		ft_putstr_fd("\b", 1);
 	else
-		printf("\b\n");
+		ft_putendl_fd("\b", 1);
 }
 
 void	ft_echo(t_cmd *cmd, t_working_info *info)


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - echo 빌트인의 -n 옵션을 사용했을때 라다이렉션이 무시되고 터미널로만 output이 되는 버그고침
 ## 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - echo빌트인에서 printf함수를 지우고 write로 직접 fd를 설정하게 함.
 
